### PR TITLE
Add simple React chess AI

### DIFF
--- a/fronted/src/App.css
+++ b/fronted/src/App.css
@@ -1,38 +1,4 @@
 .App {
   text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  font-family: sans-serif;
 }

--- a/fronted/src/App.js
+++ b/fronted/src/App.js
@@ -1,23 +1,12 @@
-import logo from './logo.svg';
+import React from 'react';
 import './App.css';
+import ChessBoard from './ChessBoard';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <h1>Ajedrez</h1>
+      <ChessBoard />
     </div>
   );
 }

--- a/fronted/src/App.test.js
+++ b/fronted/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders chess heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Ajedrez/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/fronted/src/ChessBoard.css
+++ b/fronted/src/ChessBoard.css
@@ -1,0 +1,19 @@
+.chess-board {
+  border-collapse: collapse;
+  margin: 20px auto;
+}
+
+.cell {
+  width: 60px;
+  height: 60px;
+  text-align: center;
+  vertical-align: middle;
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+.light { background: #f0d9b5; }
+.dark { background: #b58863; }
+.selected { outline: 2px solid red; }
+.valid { outline: 2px solid green; }
+.status { margin-bottom: 10px; }

--- a/fronted/src/ChessBoard.js
+++ b/fronted/src/ChessBoard.js
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import AjedrezCore from './core/AjedrezCore';
+import AlfaBeta from './core/AlfaBeta';
+import './ChessBoard.css';
+
+const PIECES = {
+  'P': '♙', 'N': '♘', 'B': '♗', 'R': '♖', 'Q': '♕', 'K': '♔',
+  'p': '♟', 'n': '♞', 'b': '♝', 'r': '♜', 'q': '♛', 'k': '♚'
+};
+
+function ChessBoard() {
+  const [core] = useState(() => new AjedrezCore());
+  const [ai] = useState(() => new AlfaBeta(core.estado, 'negro'));
+  const [board, setBoard] = useState(core.getEstado());
+  const [selected, setSelected] = useState(null);
+  const [validMoves, setValidMoves] = useState([]);
+  const [status, setStatus] = useState('en curso');
+
+  const handleCellClick = (r, c) => {
+    if (status !== 'en curso') return;
+    if (selected) {
+      const moved = core.moverPieza(selected, [r, c]);
+      if (moved) {
+        setBoard(core.getEstado());
+        let nextStatus = core.estadoPartida();
+        setStatus(nextStatus);
+        if (nextStatus === 'en curso') {
+          ai.hacerJugada();
+          setBoard(core.getEstado());
+          nextStatus = core.estadoPartida();
+          setStatus(nextStatus);
+        }
+      }
+      setSelected(null);
+      setValidMoves([]);
+    } else {
+      const pieza = board[r][c];
+      if (
+        pieza &&
+        core.estado.colorPieza(pieza) === core.estado.jugadorActual()
+      ) {
+        setSelected([r, c]);
+        setValidMoves(core.getPiezasValidas(r, c));
+      }
+    }
+  };
+
+  return (
+    <div>
+      <div className="status">Turno: {core.estado.jugadorActual()} - {status}</div>
+      <table className="chess-board">
+        <tbody>
+          {board.map((row, r) => (
+            <tr key={r}>
+              {row.map((piece, c) => {
+                const isDark = (r + c) % 2 === 1;
+                const isSel = selected && selected[0] === r && selected[1] === c;
+                const isValid = validMoves.some(
+                  ([rf, cf]) => rf === r && cf === c
+                );
+                const classes = [
+                  'cell',
+                  isDark ? 'dark' : 'light',
+                  isSel ? 'selected' : '',
+                  isValid ? 'valid' : ''
+                ]
+                  .filter(Boolean)
+                  .join(' ');
+                return (
+                  <td
+                    key={c}
+                    className={classes}
+                    onClick={() => handleCellClick(r, c)}
+                  >
+                    {PIECES[piece] || ''}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default ChessBoard;

--- a/fronted/src/core/AjedrezCore.js
+++ b/fronted/src/core/AjedrezCore.js
@@ -1,0 +1,76 @@
+import Tablero from './Tablero.js';
+import Estado from './EstadoAjedrez.js';
+import { mover_valido } from './ComprobarMovFichas.js';
+
+/**
+ * Clase que expone una interfaz simple para interactuar con el
+ * motor de ajedrez sin realizar ninguna operación de entrada/salida.
+ */
+class AjedrezCore {
+    constructor() {
+        this.tablero = new Tablero();
+        this.estado = new Estado(this.tablero);
+    }
+
+    /** Devuelve una copia del tablero actual. */
+    getEstado() {
+        return this.tablero.getEstado();
+    }
+
+    /**
+     * Intenta mover una pieza. Devuelve true si el movimiento es válido
+     * y se actualizó el estado.
+     * @param {number[]} origen [fila, col]
+     * @param {number[]} destino [fila, col]
+     */
+    moverPieza(origen, destino) {
+        const pieza = this.tablero.tablero[origen[0]][origen[1]];
+        if (!pieza) return false;
+        const tipo = this.estado.tipoPieza(pieza);
+        const jugador = this.estado.jugadorActual();
+        if (
+            mover_valido(tipo, origen, destino, this.tablero.tablero, jugador)
+        ) {
+            this.estado.jugada(origen, destino);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Devuelve todos los destinos válidos para la pieza en [fila, col].
+     * @param {number} fila
+     * @param {number} col
+     * @returns {Array<[number,number]>}
+     */
+    getPiezasValidas(fila, col) {
+        const pieza = this.tablero.tablero[fila][col];
+        if (!pieza) return [];
+        const color = this.estado.jugadorActual();
+        if (this.estado.colorPieza(pieza) !== color) return [];
+        const tipo = this.estado.tipoPieza(pieza);
+        const movimientos = [];
+        for (let r = 0; r < 8; r++) {
+            for (let c = 0; c < 8; c++) {
+                if (r === fila && c === col) continue;
+                if (mover_valido(tipo, [fila, col], [r, c], this.tablero.tablero, color)) {
+                    movimientos.push([r, c]);
+                }
+            }
+        }
+        return movimientos;
+    }
+
+    /**
+     * Devuelve el estado de la partida: 'en curso', 'blanco', 'negro' o 'tablas'.
+     */
+    estadoPartida() {
+        if (!this.estado.terminado()) return 'en curso';
+        const g = this.estado.ganador(this.estado.jugadorActual());
+        if (g === 1) return 'blanco';
+        if (g === -1) return 'negro';
+        return 'tablas';
+    }
+}
+
+export default AjedrezCore;

--- a/fronted/src/core/AlfaBeta.js
+++ b/fronted/src/core/AlfaBeta.js
@@ -1,0 +1,218 @@
+class AlfaBeta {
+    static VALOR_PIEZA = {
+        'P': 100, 'N': 320, 'B': 330, 'R': 500, 'Q': 900, 'K': 20000,
+        'p': -100, 'n': -320, 'b': -330, 'r': -500, 'q': -900, 'k': -20000
+    };
+
+    static PST_PAWN = [
+        0,5,5,-10,-10,5,5,0,
+        5,10,10,0,0,10,10,5,
+        0,0,0,20,20,0,0,0,
+        5,5,10,25,25,10,5,5,
+        10,10,20,30,30,20,10,10,
+        20,20,30,35,35,30,20,20,
+        50,50,50,50,50,50,50,50,
+        0,0,0,0,0,0,0,0
+    ];
+    static PST_KNIGHT = [
+        -50,-40,-30,-30,-30,-30,-40,-50,
+        -40,-20,0,5,5,0,-20,-40,
+        -30,5,10,15,15,10,5,-30,
+        -30,0,15,20,20,15,0,-30,
+        -30,5,15,20,20,15,5,-30,
+        -30,0,10,15,15,10,0,-30,
+        -40,-20,0,0,0,0,-20,-40,
+        -50,-40,-30,-30,-30,-30,-40,-50
+    ];
+    static PST_BISHOP = [
+        -20,-10,-10,-10,-10,-10,-10,-20,
+        -10,0,0,0,0,0,0,-10,
+        -10,0,5,10,10,5,0,-10,
+        -10,5,5,10,10,5,5,-10,
+        -10,0,10,10,10,10,0,-10,
+        -10,10,10,10,10,10,10,-10,
+        -10,5,0,0,0,0,5,-10,
+        -20,-10,-10,-10,-10,-10,-10,-20
+    ];
+    static PST_ROOK = [
+        0,0,0,5,5,0,0,0,
+        5,10,10,10,10,10,10,5,
+        -5,0,0,0,0,0,0,-5,
+        -5,0,0,0,0,0,0,-5,
+        -5,0,0,0,0,0,0,-5,
+        -5,0,0,0,0,0,0,-5,
+        -5,0,0,0,0,0,0,-5,
+        0,0,0,5,5,0,0,0
+    ];
+    static PST_QUEEN = [
+        -20,-10,-10,-5,-5,-10,-10,-20,
+        -10,0,0,0,0,0,0,-10,
+        -10,0,5,5,5,5,0,-10,
+        -5,0,5,5,5,5,0,-5,
+        0,0,5,5,5,5,0,-5,
+        -10,5,5,5,5,5,0,-10,
+        -10,0,5,0,0,0,0,-10,
+        -20,-10,-10,-5,-5,-10,-10,-20
+    ];
+    static PST_KING_MG = [
+        -30,-40,-40,-50,-50,-40,-40,-30,
+        -30,-40,-40,-50,-50,-40,-40,-30,
+        -30,-40,-40,-50,-50,-40,-40,-30,
+        -30,-40,-40,-50,-50,-40,-40,-30,
+        -20,-30,-30,-40,-40,-30,-30,-20,
+        -10,-20,-20,-20,-20,-20,-20,-10,
+        20,20,0,0,0,0,20,20,
+        20,30,10,0,0,10,30,20
+    ];
+    static PST_KING_EG = [
+        -50,-40,-30,-20,-20,-30,-40,-50,
+        -30,-20,-10,0,0,-10,-20,-30,
+        -30,-10,20,30,30,20,-10,-30,
+        -30,-10,30,40,40,30,-10,-30,
+        -30,-10,30,40,40,30,-10,-30,
+        -30,-10,20,30,30,20,-10,-30,
+        -30,-30,0,0,0,0,-30,-30,
+        -50,-30,-30,-30,-30,-30,-30,-50
+    ];
+
+    constructor(estado, color, max_depth = 3) {
+        this.estado = estado;
+        this.color = color;
+        this.max_depth = max_depth;
+    }
+
+    evaluar(estado) {
+        const board = estado.tablero.tablero;
+        let score = 0;
+        for (let r = 0; r < 8; r++) {
+            for (let c = 0; c < 8; c++) {
+                const pieza = board[r][c];
+                if (!pieza) continue;
+                score += AlfaBeta.VALOR_PIEZA[pieza] ?? 0;
+                const idx = r * 8 + c;
+                const signo = (pieza === pieza.toUpperCase() && this.color === 'blanco') ||
+                (pieza === pieza.toLowerCase() && this.color === 'negro') ? 1 : -1;
+                const up = pieza.toUpperCase();
+                if (up === 'P') score += signo * AlfaBeta.PST_PAWN[idx];
+                else if (up === 'N') score += signo * AlfaBeta.PST_KNIGHT[idx];
+                else if (up === 'B') score += signo * AlfaBeta.PST_BISHOP[idx];
+                else if (up === 'R') score += signo * AlfaBeta.PST_ROOK[idx];
+                else if (up === 'Q') score += signo * AlfaBeta.PST_QUEEN[idx];
+                else if (up === 'K') score += signo * (this.esFinal(board) ? AlfaBeta.PST_KING_EG[idx] : AlfaBeta.PST_KING_MG[idx]);
+            }
+        }
+        score += this.evalPeones(board);
+        score += this.evalSeguridadRey(board);
+        for (const [r,c] of [[3,3],[3,4],[4,3],[4,4]]) {
+            const pieza = board[r][c];
+            if (!pieza) continue;
+            const signo = (pieza === pieza.toUpperCase() && this.color === 'blanco') ||
+            (pieza === pieza.toLowerCase() && this.color === 'negro') ? 1 : -1;
+            score += 20 * signo;
+        }
+        const mi_moves = this.estado.sucesores_para(this.color).length;
+        const otro = this.color === 'blanco' ? 'negro' : 'blanco';
+        const op_moves = this.estado.sucesores_para(otro).length;
+        score += 10 * (mi_moves - op_moves);
+        if (this.esFinal(board)) score += this.evalActividadRey(board);
+        return score;
+    }
+
+    evalPeones(board) {
+        let val = 0;
+        const friendly = this.color === 'blanco' ? 'P' : 'p';
+        const enemy = this.color === 'blanco' ? 'p' : 'P';
+        for (let c = 0; c < 8; c++) {
+            for (let r = 0; r < 8; r++) {
+                if (board[r][c] === friendly) {
+                    const cols = [c - 1, c + 1];
+                    if (cols.every(c2 => !(0 <= c2 && c2 < 8 && board.some(row => row[c2] === friendly)))) {
+                        val -= 15;
+                    }
+                    const ahead = this.color === 'blanco' ? [...Array(r).keys()].reverse() : Array.from({length:8-r-1},(_,i)=>r+1+i);
+                    if (ahead.every(r2 => board[r2][c] !== enemy)) val += 20;
+                }
+            }
+        }
+        return val;
+    }
+
+    evalSeguridadRey(board) {
+        let val = 0;
+        const pawn = this.color === 'blanco' ? 'P' : 'p';
+        const king = this.color === 'blanco' ? 'K' : 'k';
+        let rk = null, ck = null;
+        for (let r = 0; r < 8 && rk === null; r++) {
+            for (let c = 0; c < 8; c++) {
+                if (board[r][c] === king) { rk = r; ck = c; break; }
+            }
+        }
+        for (let dr = -1; dr <= 1; dr++) {
+            for (let dc = -1; dc <= 1; dc++) {
+                if (dr === 0 && dc === 0) continue;
+                const r2 = rk + dr, c2 = ck + dc;
+                if (0 <= r2 && r2 < 8 && 0 <= c2 && c2 < 8 && board[r2][c2] === pawn) val += 1;
+            }
+        }
+        return val;
+    }
+
+    esFinal(board) {
+        let tot = 0;
+        for (const row of board) {
+            for (const p of row) {
+                if (!p || p.toUpperCase() === 'K') continue;
+                tot += Math.abs(AlfaBeta.VALOR_PIEZA[p] ?? 0);
+            }
+        }
+        return tot < 2000;
+    }
+
+    evalActividadRey(board) {
+        let val = 0;
+        const king = this.color === 'blanco' ? 'K' : 'k';
+        for (let r = 0; r < 8; r++) {
+            for (let c = 0; c < 8; c++) {
+                if (board[r][c] === king) {
+                    const dist = Math.abs(r - 3.5) + Math.abs(c - 3.5);
+                    val += Math.trunc(20 - dist * 4);
+                }
+            }
+        }
+        return val;
+    }
+
+    AlfaBeta(estado, depth, alfa, beta, maximizar) {
+        if (depth === 0 || estado.terminado()) return [this.evaluar(estado), null];
+        let mejorJugada = null;
+        if (maximizar) {
+            let valor = -Infinity;
+            for (const [sucesor, jugada] of estado.sucesores()) {
+                const [puntos] = this.AlfaBeta(sucesor, depth - 1, alfa, beta, false);
+                if (puntos > valor) { valor = puntos; mejorJugada = jugada; }
+                alfa = Math.max(alfa, valor);
+                if (alfa >= beta) break;
+            }
+            return [valor, mejorJugada];
+        } else {
+            let valor = Infinity;
+            for (const [sucesor, jugada] of estado.sucesores()) {
+                const [puntos] = this.AlfaBeta(sucesor, depth - 1, alfa, beta, true);
+                if (puntos < valor) { valor = puntos; mejorJugada = jugada; }
+                beta = Math.min(beta, valor);
+                if (beta <= alfa) break;
+            }
+            return [valor, mejorJugada];
+        }
+    }
+
+    hacerJugada() {
+        const maximizar = this.estado.jugadorActual() === this.color;
+        const [, jugada] = this.AlfaBeta(this.estado, this.max_depth, -Infinity, Infinity, maximizar);
+        if (!jugada) return;
+        const [f1, c1, f2, c2] = jugada;
+        this.estado.jugada([f1, c1], [f2, c2]);
+    }
+}
+
+export default AlfaBeta;

--- a/fronted/src/core/ComprobarMovFichas.js
+++ b/fronted/src/core/ComprobarMovFichas.js
@@ -1,0 +1,99 @@
+function torre(origen, destino) {
+    const [filaA, colA] = origen;
+    const [filaD, colD] = destino;
+    return filaA === filaD || colA === colD;
+}
+
+function alfil(origen, destino) {
+    const [filaA, colA] = origen;
+    const [filaD, colD] = destino;
+    return Math.abs(filaA - filaD) === Math.abs(colA - colD);
+}
+
+function caballo(origen, destino) {
+    const [filaA, colA] = origen;
+    const [filaD, colD] = destino;
+    const x = Math.abs(filaA - filaD);
+    const y = Math.abs(colA - colD);
+    return (x === 2 && y === 1) || (x === 1 && y === 2);
+}
+
+function reina(origen, destino) {
+    return torre(origen, destino) || alfil(origen, destino);
+}
+
+function rey(origen, destino) {
+    const [filaA, colA] = origen;
+    const [filaD, colD] = destino;
+    const x = Math.abs(filaA - filaD);
+    const y = Math.abs(colA - colD);
+    return x <= 1 && y <= 1 && (x + y !== 0);
+}
+
+function peon(origen, destino, color) {
+    const [filaA, colA] = origen;
+    const [filaD, colD] = destino;
+    const direccion = color === 'blanco' ? -1 : 1;
+    const filaInicio = color === 'blanco' ? 6 : 1;
+    if (filaD - filaA === direccion && colA === colD) return true;
+    if (filaA === filaInicio && filaD - filaA === 2 * direccion && colA === colD)
+        return true;
+    return false;
+}
+
+function caminoLibre(origen, destino, tablero) {
+    let [filaA, colA] = origen;
+    const [filaD, colD] = destino;
+    const pasoFila = filaA !== filaD ? (filaD - filaA) / Math.abs(filaD - filaA) : 0;
+    const pasoCol = colA !== colD ? (colD - colA) / Math.abs(colD - colA) : 0;
+    filaA += pasoFila;
+    colA += pasoCol;
+    while (filaA !== filaD || colA !== colD) {
+        if (tablero[filaA][colA] !== null) return false;
+        filaA += pasoFila;
+        colA += pasoCol;
+    }
+    return true;
+}
+
+export function mover_valido(pieza, origen, destino, tablero, color) {
+    const [filaD, colD] = destino;
+    const destino_pieza = tablero[filaD][colD];
+    let color_destino = null;
+    if (destino_pieza && typeof destino_pieza === 'string' && destino_pieza.trim() !== '') {
+        color_destino = destino_pieza === destino_pieza.toUpperCase() ? 'blanco' : 'negro';
+    }
+    if (color_destino === color) return false;
+    const mapping = { p: 'peon', n: 'caballo', r: 'torre', b: 'alfil', q: 'reina', k: 'rey' };
+    const pieza_tipo = mapping[pieza] || pieza;
+    if (pieza_tipo === 'torre') {
+        return torre(origen, destino) && caminoLibre(origen, destino, tablero);
+    } else if (pieza_tipo === 'alfil') {
+        return alfil(origen, destino) && caminoLibre(origen, destino, tablero);
+    } else if (pieza_tipo === 'reina') {
+        return reina(origen, destino) && caminoLibre(origen, destino, tablero);
+    } else if (pieza_tipo === 'caballo') {
+        return caballo(origen, destino);
+    } else if (pieza_tipo === 'rey') {
+        return rey(origen, destino);
+    } else if (pieza_tipo === 'peon') {
+        const [filaA, colA] = origen;
+        const direccion = color === 'blanco' ? -1 : 1;
+        const filaInicio = color === 'blanco' ? 6 : 1;
+        if (colA === colD) {
+            if (filaD - filaA === direccion && tablero[filaD][colD] === null) return true;
+            if (filaA === filaInicio && filaD - filaA === 2 * direccion) {
+                const intermedia = filaA + direccion;
+                if (tablero[intermedia][colD] === null && tablero[filaD][colD] === null) return true;
+            }
+        } else if (Math.abs(colD - colA) === 1 && filaD - filaA === direccion) {
+            if (color_destino !== null && color_destino !== color) return true;
+            return false;
+        }
+        return false;
+    } else {
+        throw new Error(`Pieza desconocida: ${pieza}`);
+    }
+}
+
+export { torre, alfil, caballo, reina, rey, peon, caminoLibre };

--- a/fronted/src/core/EstadoAjedrez.js
+++ b/fronted/src/core/EstadoAjedrez.js
@@ -1,0 +1,88 @@
+import { mover_valido } from './ComprobarMovFichas.js';
+import Tablero from './Tablero.js';
+
+class Estado {
+    constructor(tablero) {
+        this.tablero = tablero;
+        this.turnoBlanco = true;
+        this.turnoNegro = false;
+    }
+
+    jugadorActual() {
+        return this.turnoBlanco ? 'blanco' : 'negro';
+    }
+
+    colorPieza(pieza) {
+        if (!pieza) return null;
+        return pieza === pieza.toUpperCase() ? 'blanco' : 'negro';
+    }
+
+    tipoPieza(pieza) {
+        const letras = {
+            'P': 'peon', 'N': 'caballo', 'B': 'alfil', 'R': 'torre', 'Q': 'reina', 'K': 'rey',
+            'p': 'peon', 'n': 'caballo', 'b': 'alfil', 'r': 'torre', 'q': 'reina', 'k': 'rey'
+        };
+        return letras[pieza];
+    }
+
+    sucesores() {
+        const lista = [];
+        const jugador = this.jugadorActual();
+        for (let fila = 0; fila < 8; fila++) {
+            for (let col = 0; col < 8; col++) {
+                const pieza = this.tablero.tablero[fila][col];
+                if (!pieza || this.colorPieza(pieza) !== jugador) continue;
+                const tipo = this.tipoPieza(pieza);
+                for (let df = 0; df < 8; df++) {
+                    for (let dc = 0; dc < 8; dc++) {
+                        if (df === fila && dc === col) continue;
+                        if (!mover_valido(tipo, [fila, col], [df, dc], this.tablero.tablero, jugador)) continue;
+                        const nuevoTablero = this.tablero.clone();
+                        nuevoTablero.tablero[df][dc] = pieza;
+                        nuevoTablero.tablero[fila][col] = null;
+                        const nuevoEstado = new Estado(nuevoTablero);
+                        nuevoEstado.turnoBlanco = !this.turnoBlanco;
+                        nuevoEstado.turnoNegro = !this.turnoNegro;
+                        lista.push([nuevoEstado, [fila, col, df, dc]]);
+                    }
+                }
+            }
+        }
+        return lista;
+    }
+
+    terminado() {
+        const plano = this.tablero.tablero.flat();
+        return !plano.includes('K') || !plano.includes('k');
+    }
+
+    ganador(fichaIa) {
+        const hayReyBlanco = this.tablero.tablero.some(f => f.includes('K'));
+        const hayReyNegro = this.tablero.tablero.some(f => f.includes('k'));
+        if (!hayReyBlanco) return fichaIa === 'negro' ? 1 : -1;
+        if (!hayReyNegro) return fichaIa === 'blanco' ? 1 : -1;
+        return 0;
+    }
+
+    jugada(origen, destino) {
+        const pieza = this.tablero.tablero[origen[0]][origen[1]];
+        this.tablero.tablero[destino[0]][destino[1]] = pieza;
+        this.tablero.tablero[origen[0]][origen[1]] = null;
+        this.turnoBlanco = !this.turnoBlanco;
+    }
+
+    sucesores_para(color) {
+        const orig = this.turnoBlanco;
+        this.turnoBlanco = color === 'blanco';
+        const lst = this.sucesores();
+        this.turnoBlanco = orig;
+        return lst;
+    }
+
+    cambiarturno() {
+        this.turnoBlanco = !this.turnoBlanco;
+        this.turnoNegro = !this.turnoNegro;
+    }
+}
+
+export default Estado;

--- a/fronted/src/core/Tablero.js
+++ b/fronted/src/core/Tablero.js
@@ -1,0 +1,30 @@
+const BOARD_SIZE = 8;
+
+class Tablero {
+    constructor() {
+        this.tablero = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(null));
+        this.colocarFichas();
+    }
+
+    /**
+     * Devuelve una copia del estado actual del tablero.
+     */
+    getEstado() {
+        return this.tablero.map(f => f.slice());
+    }
+
+    colocarFichas() {
+        this.tablero[0] = ['r','n','b','q','k','b','n','r'];
+        this.tablero[1] = Array(8).fill('p');
+        this.tablero[6] = Array(8).fill('P');
+        this.tablero[7] = ['R','N','B','Q','K','B','N','R'];
+    }
+
+    clone() {
+        const nuevo = new Tablero();
+        nuevo.tablero = this.tablero.map(fila => fila.slice());
+        return nuevo;
+    }
+}
+
+export default Tablero;

--- a/fronted/src/core/funciones.js
+++ b/fronted/src/core/funciones.js
@@ -1,0 +1,11 @@
+export function texto_coordenadas(pos) {
+    const col = pos.charCodeAt(0) - 'a'.charCodeAt(0);
+    const fila = 8 - parseInt(pos[1], 10);
+    return [fila, col];
+}
+
+export function coordenadas_texto(fila, col) {
+    const letra = String.fromCharCode('a'.charCodeAt(0) + col);
+    const num = 8 - fila;
+    return `${letra}${num}`;
+}


### PR DESCRIPTION
## Summary
- integrate AlfaBeta engine in React core
- update chess board logic to trigger AI moves

## Testing
- `npm test --silent --prefix fronted` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685463adc344832d8c74fb5d9e2ccb3f